### PR TITLE
match.find(0) finds lines of text on desktop and android

### DIFF
--- a/core/src/com/kyper/yarn/Lexer.java
+++ b/core/src/com/kyper/yarn/Lexer.java
@@ -324,7 +324,7 @@ public class Lexer {
 					column_number = text_start_index;
 					
 
-					match.find(column_number);
+					match.find(0);
 
 					//TODO: ====
 					//THIS IS PROBABLY WRONG


### PR DESCRIPTION
when match.find(column_number) is used, android is not able to match on TokenType.Text - match.find(0) works for android and doesn't change the behavior for desktop